### PR TITLE
Update czech status text

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -48,7 +48,7 @@ const groupSessionsByDate = (sessions: GameSessionWithSignups[], locale: Locale)
   // Create special lane for sessions without date (first)
   const unscheduledLane: DateLane = {
     date: 'unscheduled',
-    dateLabel: locale === 'cs' ? 'Bez data' : 'Unscheduled',
+    dateLabel: locale === 'cs' ? 'Nenaplánováno' : 'Unscheduled',
     sessions: []
   };
   

--- a/src/components/SessionCard.tsx
+++ b/src/components/SessionCard.tsx
@@ -91,11 +91,11 @@ export default function SessionCard({ session, onUpdate, locale }: SessionCardPr
       console.error('Failed to remove signup:', error);
       alert(t(locale, 'failedToRemovePlayer'));
     }
-  };
-
+    };
+  
   const formatSessionTimeRange = (session: GameSessionWithSignups) => {
     if (!session.scheduledAt) {
-      return locale === 'cs' ? 'Bez data' : 'Unscheduled';
+      return locale === 'cs' ? 'Nenaplánováno' : 'Unscheduled';
     }
     
     try {

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -479,7 +479,7 @@ const translations: Record<Locale, Translations> = {
     continue: 'Pokračovat',
     login: 'Přihlásit',
     logout: 'Odhlásit',
-    unscheduled: 'Bez data',
+    unscheduled: 'Nenaplánováno',
     events: 'Události',
     event: 'Událost',
     eventName: 'Název události',


### PR DESCRIPTION
Update Czech text 'Bez data' to 'Nenaplánováno' to better reflect the 'unscheduled' status.

---
<a href="https://cursor.com/background-agent?bcId=bc-5c379f9c-3131-46f9-9dfc-6de18571c59a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5c379f9c-3131-46f9-9dfc-6de18571c59a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

